### PR TITLE
Improve performance (throughput)

### DIFF
--- a/denops/@ddu-sources/file_rec.ts
+++ b/denops/@ddu-sources/file_rec.ts
@@ -1,15 +1,13 @@
 import { BaseSource, Item } from "https://deno.land/x/ddu_vim@v0.12.2/types.ts";
 import { Denops, fn } from "https://deno.land/x/ddu_vim@v0.12.2/deps.ts";
-import { ActionData } from "https://deno.land/x/ddu_kind_file@v0.2.0/file.ts";
-
 import { join, resolve } from "https://deno.land/std@0.125.0/path/mod.ts";
+import { ActionData } from "https://deno.land/x/ddu_kind_file@v0.2.0/file.ts";
 import { relative } from "https://deno.land/std@0.125.0/path/mod.ts";
 import { deferred } from "https://deno.land/std@0.125.0/async/mod.ts";
 
-const chunkMinSize = 100;
-const chunkMaxSize = 20000;
-
-const aborted = Symbol("aborted");
+const chunkSize = 1000;
+const enqueueSize1st = 1000;
+const enqueueSize2nd = 100000;
 
 type Params = {
   ignoredDirectories: string[];
@@ -35,24 +33,22 @@ export class Source extends BaseSource<Params> {
           sourceParams.ignoredDirectories,
           abortController.signal,
         );
-        let chunkSize = chunkMinSize;
-        let chunk: Item<ActionData>[] = [];
+        let enqueueSize = enqueueSize1st;
+        let items: Item<ActionData>[] = [];
         try {
-          for await (const item of it) {
-            chunk.push(item);
-            if (chunk.length > chunkSize) {
-              controller.enqueue(chunk);
-              chunk = [];
-              if (chunkSize < chunkMaxSize) {
-                chunkSize += chunkSize;
-              }
+          for await (const chunk of it) {
+            items = items.concat(chunk);
+            if (items.length >= enqueueSize) {
+              enqueueSize = enqueueSize2nd;
+              controller.enqueue(items);
+              items = [];
             }
           }
-          if (chunk.length) {
-            controller.enqueue(chunk);
+          if (items.length) {
+            controller.enqueue(items);
           }
         } catch (e: unknown) {
-          if (e === aborted) {
+          if (e instanceof AbortedError) {
             return;
           }
           console.error(e);
@@ -79,44 +75,84 @@ async function* walk(
   root: string,
   ignoredDirectories: string[],
   signal: AbortSignal,
-): AsyncGenerator<Item<ActionData>> {
-  const waiter = deferred<never>();
-  signal.addEventListener("abort", () => waiter.reject(aborted));
-
-  const walk = async function* (dir: string): AsyncGenerator<Item<ActionData>> {
-    const it = Deno.readDir(dir)[Symbol.asyncIterator]();
-    while (true) {
-      try {
-        const { done, value } = await Promise.race([waiter, it.next()]);
-        if (done || value == undefined) {
-          return;
-        }
-        const entry = value as Deno.DirEntry;
+): AsyncGenerator<Item<ActionData>[]> {
+  const walk = async function* (
+    dir: string,
+  ): AsyncGenerator<Item<ActionData>[]> {
+    let chunk: Item<ActionData>[] = [];
+    try {
+      for await (const entry of abortable(Deno.readDir(dir), signal)) {
         const abspath = join(dir, entry.name);
 
         if (!entry.isDirectory) {
-          yield {
+          const n = chunk.push({
             word: relative(root, abspath),
             action: {
               path: abspath,
             },
-          };
+          });
+          if (n >= chunkSize) {
+            yield chunk;
+            chunk = [];
+          }
         } else {
           if (ignoredDirectories.includes(entry.name)) {
             continue;
           }
           yield* walk(abspath);
         }
-      } catch (e: unknown) {
-        if (e instanceof Deno.errors.PermissionDenied) {
-          // Ignore this error
-          // See https://github.com/Shougo/ddu-source-file_rec/issues/2
-          continue;
-        }
-
-        throw e;
       }
+      if (chunk.length) {
+        yield chunk;
+      }
+    } catch (e: unknown) {
+      if (e instanceof Deno.errors.PermissionDenied) {
+        // Ignore this error
+        // See https://github.com/Shougo/ddu-source-file_rec/issues/2
+        return;
+      }
+      throw e;
     }
   };
   yield* walk(root);
+}
+
+// XXX: Replace it with the following
+// https://github.com/denoland/deno_std/pull/1939
+class AbortedError extends Error {
+  // This `reason` comes from `AbortSignal` thus must be `any`.
+  // deno-lint-ignore no-explicit-any
+  reason?: any;
+
+  // This `reason` comes from `AbortSignal` thus must be `any`.
+  // deno-lint-ignore no-explicit-any
+  constructor(reason?: any) {
+    super(reason ? `Aborted: ${reason}` : "Aborted");
+    this.name = "AbortedError";
+    this.reason = reason;
+  }
+}
+
+// XXX: Replace it with the following
+// https://github.com/denoland/deno_std/pull/1939
+async function* abortable<T>(
+  p: AsyncIterable<T>,
+  signal: AbortSignal,
+): AsyncGenerator<T> {
+  if (signal.aborted) {
+    throw new AbortedError(signal.reason);
+  }
+  const waiter = deferred<never>();
+  const abort = () => waiter.reject(new AbortedError(signal.reason));
+  signal.addEventListener("abort", abort, { once: true });
+
+  const it = p[Symbol.asyncIterator]();
+  while (true) {
+    const { done, value } = await Promise.race([waiter, it.next()]);
+    if (done) {
+      signal.removeEventListener("abort", abort);
+      return;
+    }
+    yield value;
+  }
 }


### PR DESCRIPTION
**Personally, I feel that the complexity of a few hundred milliseconds for 200,000 entries is not worth the cost. Therefore, I will leave it to you to decide whether to merge them.**

When using async iterator, there seems to be a problem that iterating on individual elements affects performance.
In other words, it's likely that Deno has the same problem as the following issue that exists in Node.

https://github.com/nodejs/node/issues/31979

So I tried to avoid this problem by using `AsyncGenerator<T[]>` instead and seems working.


### Results of `{'profile': 1}`

I've made 200,000 files with

```sh
#!/bin/bash
mkdir -p out
for i in {1..200000}; do
  touch out/$i.txt
done
```

Then run `call ddu#start({'profile': 1})` on `out` directory.

| Before #3 | After #3 | This PR |
| --------- | -------- | ------- |
| 1167 ms   | 1591 ms  | 1213 ms |
| 1217 ms   | 1569 ms  | 1165 ms |
| 1165 ms   | 1588 ms  | 1148 ms |
| 1186 ms   | 1562 ms  | 1155 ms |
| 1121 ms   | 1493 ms  | 1151 ms |
