### PR TITLE
Search within a directory pointed to by the searched symbolic link

### DIFF
--- a/doc/ddu-source-file_rec.txt
+++ b/doc/ddu-source-file_rec.txt
@@ -57,8 +57,8 @@ ignoredDirectories	(string[])
 
 				*ddu-source-file_rec-param-isExpandSymbDir*
 isExpandSymbDir 	(bool)
-		When true, It search files in a directory to which 
-		symbolic link points.
+		When true, It search within a directory pointed to by 
+		searched symbolic link.
 
 		Default: "v:false"
 

--- a/doc/ddu-source-file_rec.txt
+++ b/doc/ddu-source-file_rec.txt
@@ -55,5 +55,13 @@ ignoredDirectories	(string[])
 
 		Default: ".git"
 
+				*ddu-source-file_rec-param-isExpandSymbDir*
+isExpandSymbDir 	(bool)
+		When true, It search file in directory which 
+		symbolic link points.
+
+		Default: "v:false"
+
+
 ==============================================================================
 vim:tw=78:ts=8:ft=help:norl:noet:fen:noet:

--- a/doc/ddu-source-file_rec.txt
+++ b/doc/ddu-source-file_rec.txt
@@ -57,7 +57,7 @@ ignoredDirectories	(string[])
 
 				*ddu-source-file_rec-param-isExpandSymbDir*
 isExpandSymbDir 	(bool)
-		When true, It search within a directory pointed to by 
+		When true, It search within a directory pointed to by
 		searched symbolic link.
 
 		Default: "v:false"

--- a/doc/ddu-source-file_rec.txt
+++ b/doc/ddu-source-file_rec.txt
@@ -57,7 +57,7 @@ ignoredDirectories	(string[])
 
 				*ddu-source-file_rec-param-isExpandSymbDir*
 isExpandSymbDir 	(bool)
-		When true, It search file in directory which 
+		When true, It search files in a directory to which 
 		symbolic link points.
 
 		Default: "v:false"

--- a/doc/tags
+++ b/doc/tags
@@ -1,0 +1,8 @@
+ddu-source-file_rec-contents	ddu-source-file_rec.txt	/*ddu-source-file_rec-contents*
+ddu-source-file_rec-examples	ddu-source-file_rec.txt	/*ddu-source-file_rec-examples*
+ddu-source-file_rec-install	ddu-source-file_rec.txt	/*ddu-source-file_rec-install*
+ddu-source-file_rec-introduction	ddu-source-file_rec.txt	/*ddu-source-file_rec-introduction*
+ddu-source-file_rec-param-chunkSize	ddu-source-file_rec.txt	/*ddu-source-file_rec-param-chunkSize*
+ddu-source-file_rec-param-ignoredDirectories	ddu-source-file_rec.txt	/*ddu-source-file_rec-param-ignoredDirectories*
+ddu-source-file_rec-params	ddu-source-file_rec.txt	/*ddu-source-file_rec-params*
+ddu-source-file_rec.txt	ddu-source-file_rec.txt	/*ddu-source-file_rec.txt*

--- a/doc/tags
+++ b/doc/tags
@@ -1,8 +1,0 @@
-ddu-source-file_rec-contents	ddu-source-file_rec.txt	/*ddu-source-file_rec-contents*
-ddu-source-file_rec-examples	ddu-source-file_rec.txt	/*ddu-source-file_rec-examples*
-ddu-source-file_rec-install	ddu-source-file_rec.txt	/*ddu-source-file_rec-install*
-ddu-source-file_rec-introduction	ddu-source-file_rec.txt	/*ddu-source-file_rec-introduction*
-ddu-source-file_rec-param-chunkSize	ddu-source-file_rec.txt	/*ddu-source-file_rec-param-chunkSize*
-ddu-source-file_rec-param-ignoredDirectories	ddu-source-file_rec.txt	/*ddu-source-file_rec-param-ignoredDirectories*
-ddu-source-file_rec-params	ddu-source-file_rec.txt	/*ddu-source-file_rec-params*
-ddu-source-file_rec.txt	ddu-source-file_rec.txt	/*ddu-source-file_rec.txt*


### PR DESCRIPTION
I would like that it search within a directory pointed to by the searched symbolic link.
I will leave it to you to decide whether to merge them.

# What I did

* Add 'isExpandSymbDir' in 'sourceParams'
* When 'isExpandSymbDir' is true, search within a directory to by the searched symbolic link.

# Test

## Environment

```
.
├── ddu-source-file_rec -> ../Programs/ddu-source-file_rec
│   ├── LICENSE
│   ├── README.md
│   ├── denops
│   │   └── @ddu-sources
│   │       └── file_rec.ts
│   └── doc
│       ├── ddu-source-file_rec.txt
│       └── tags
├── index.txt
├── merge.md
├── sandbox -> ../sandbox  [recursive, not followed]
└── test
    ├── test.txt
    ├── test1-1
    │   ├── test1-1.txt
    │   ├── test1-2
    │   │   ├── test -> ../../../test  [recursive, not followed]
    │   │   └── test1-2.txt
    │   └── test2-2 -> ../test2-1/test2-2
    │       ├── test1-2 -> ../../test1-1/test1-2  [recursive, not followed]
    │       └── test2-2.txt
    └── test2-1
        ├── test2-1.txt
        └── test2-2
            ├── test1-2 -> ../../test1-1/test1-2  [recursive, not followed]
            └── test2-2.txt

15 directories, 13 files
```

## Exec 

https://user-images.githubusercontent.com/42508708/210935812-0ee4acf4-8bcf-484c-ba0c-d09403b79a94.mp4
