### PR TITLE
[fix bugs] Abort when search broken links

### DIFF
--- a/denops/@ddu-sources/file_rec.ts
+++ b/denops/@ddu-sources/file_rec.ts
@@ -2,8 +2,8 @@ import {
   BaseSource,
   Item,
   SourceOptions,
-} from "https://deno.land/x/ddu_vim@v2.0.0/types.ts";
-import { Denops, fn } from "https://deno.land/x/ddu_vim@v2.0.0/deps.ts";
+} from "https://deno.land/x/ddu_vim@v2.1.0/types.ts";
+import { Denops, fn } from "https://deno.land/x/ddu_vim@v2.1.0/deps.ts";
 import { join, resolve } from "https://deno.land/std@0.171.0/path/mod.ts";
 import { ActionData } from "https://deno.land/x/ddu_kind_file@v0.3.2/file.ts";
 import { relative } from "https://deno.land/std@0.171.0/path/mod.ts";

--- a/denops/@ddu-sources/file_rec.ts
+++ b/denops/@ddu-sources/file_rec.ts
@@ -96,7 +96,8 @@ async function* walk(
             continue;
         } else if (
           (await Deno.stat(await Deno.realPath(abspath))).isFile ||
-          (!expandSymbolicLink && !entry.isDirectory)
+          (!expandSymbolicLink && !entry.isDirectory) || 
+          (!entry.isDirectory && !entry.isFile && ! entry.isSymLink)
         ) {
           const n = chunk.push({
             word: relative(root, abspath),
@@ -117,10 +118,8 @@ async function* walk(
           abspath.includes(await Deno.realPath(abspath))
         ) {
           continue;
-        } else if ( (await Deno.stat(await Deno.realPath(abspath))).isDirectory ){
-          yield* walk(abspath);
         } else {
-          continue;
+          yield* walk(abspath);
         }
       }
       if (chunk.length) {


### PR DESCRIPTION
# 問題

1. リンク先のパスが存在しない時異常終了する
2. 名前付きパイプやデバイスファイルが存在する時異常終了する

# 原因

1. `Deno.stat()`の引数に存在しないパスを渡すと異常終了する
2. `Deno.stat()`の引数に名前付きパイプやデバイスファイルを渡した時，`isFile`も`isDirectory`も`isSymlink`も`false`になる

# 解決法

1. リンク先のファイルが存在しないことを判定する`isBrokenLink()`を作成して判定
2. すべて偽のときchunkへ追加